### PR TITLE
add `semihosting` feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,9 +1,13 @@
 [package]
 name = "lm3s6965evb"
 version = "0.1.0"
-authors = ["Jorge Aparicio <jorge@japaric.io>"]
+authors = ["Jorge Aparicio <jorge@japaric.io>", "Hideki Sekine <sekineh@me.com>"]
+
+[features]
+semihosting = ["cortex-m-semihosting"]
 
 [dependencies]
 cortex-m = "0.5.2"
 cortex-m-rt = "0.5.1"
 panic-abort = "0.2.0"
+cortex-m-semihosting = { version = "0.3.1", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,11 +3,9 @@ name = "lm3s6965evb"
 version = "0.1.0"
 authors = ["Jorge Aparicio <jorge@japaric.io>", "Hideki Sekine <sekineh@me.com>"]
 
-[features]
-semihosting = ["cortex-m-semihosting"]
-
 [dependencies]
 cortex-m = "0.5.2"
 cortex-m-rt = "0.5.1"
 panic-abort = "0.2.0"
-cortex-m-semihosting = { version = "0.3.1", optional = true }
+cortex-m-semihosting = "0.3.1"
+unreachable = "1.0.0"

--- a/README.md
+++ b/README.md
@@ -137,15 +137,27 @@ from the HardFault handler causes the processor to jump to the start of the Hard
 On hardware, these instructions make the processor sleep until an interrupt signal arrives (WFI) or
 until an event occurs (WFE).
 
-## Unresolved questions
+## How to exit QEMU cleanly?
 
-If you figure these out send a PR with the answer!
+Build with 'semihosting' feature.
+This will pull in the `cortex-m-semihosting` dependency and uses syscall to exit QEMU successfully
+```
+$ cargo build --features semihosting
+```
 
-- You can terminate QEMU from the terminal by entering Ctrl-A + X, but how can you terminate QEMU
-  from within the kernel program?
+Run without `-gdb` and `-S` (stop) option.
+```
+$ qemu-system-arm \
+       -cpu cortex-m3 \
+       -machine lm3s6965evb \
+       -semihosting \
+       -nographic \
+       -kernel target/thumbv7m-none-eabi/debug/lm3s6965evb
+x = 42
+$
+```
 
-- How to make the emulated program output text to the console? I would assume that configuring and
-  writing to the serial port of the LM3S6965 should work, but I haven't tried it myself.
+The above exits immediately.
 
 ## References
 

--- a/README.md
+++ b/README.md
@@ -137,27 +137,23 @@ from the HardFault handler causes the processor to jump to the start of the Hard
 On hardware, these instructions make the processor sleep until an interrupt signal arrives (WFI) or
 until an event occurs (WFE).
 
-## How to exit QEMU cleanly?
-
-Build with 'semihosting' feature.
-This will pull in the `cortex-m-semihosting` dependency and uses syscall to exit QEMU successfully
-```
-$ cargo build --features semihosting
-```
+## Just want to run on QEMU?
 
 Run without `-gdb` and `-S` (stop) option.
+Add `-semihosting-config enable=on,target=native` to enable semihosting console output and exit.
+
 ```
 $ qemu-system-arm \
        -cpu cortex-m3 \
        -machine lm3s6965evb \
-       -semihosting \
+       -semihosting-config enable=on,target=native \
        -nographic \
        -kernel target/thumbv7m-none-eabi/debug/lm3s6965evb
 x = 42
 $
 ```
 
-The above exits immediately.
+The command exits immediately.
 
 ## References
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -29,10 +29,10 @@ fn main() -> ! {
 
         #[cfg(feature = "semihosting")]
         unsafe {
-            // system call to exit QEMU
             let mut hstdout = semihosting::hio::hstdout().unwrap();
             write!(hstdout, "x = {}\n", x);
 
+            // system call to exit successfully
             semihosting::syscall1(
                 semihosting::nr::REPORT_EXCEPTION,
                 semihosting::debug::Exception::ApplicationExit as usize,

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,11 +7,17 @@ extern crate cortex_m;
 #[macro_use(entry, exception)]
 extern crate cortex_m_rt as rt;
 
+#[cfg(feature = "semihosting")]
+extern crate cortex_m_semihosting as semihosting;
+
 extern crate panic_abort;
 
 use core::arch::arm;
 
 use rt::ExceptionFrame;
+
+#[cfg(feature = "semihosting")]
+use core::fmt::Write;
 
 entry!(main);
 
@@ -20,6 +26,18 @@ fn main() -> ! {
 
     loop {
         unsafe { arm::__NOP() }
+
+        #[cfg(feature = "semihosting")]
+        unsafe {
+            // system call to exit QEMU
+            let mut hstdout = semihosting::hio::hstdout().unwrap();
+            write!(hstdout, "x = {}\n", x);
+
+            semihosting::syscall1(
+                semihosting::nr::REPORT_EXCEPTION,
+                semihosting::debug::Exception::ApplicationExit as usize,
+            );
+        }
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,18 +6,13 @@ extern crate cortex_m;
 
 #[macro_use(entry, exception)]
 extern crate cortex_m_rt as rt;
-
-#[cfg(feature = "semihosting")]
 extern crate cortex_m_semihosting as semihosting;
-
 extern crate panic_abort;
+extern crate unreachable;
 
 use core::arch::arm;
-
-use rt::ExceptionFrame;
-
-#[cfg(feature = "semihosting")]
 use core::fmt::Write;
+use rt::ExceptionFrame;
 
 entry!(main);
 
@@ -27,16 +22,16 @@ fn main() -> ! {
     loop {
         unsafe { arm::__NOP() }
 
-        #[cfg(feature = "semihosting")]
-        unsafe {
-            let mut hstdout = semihosting::hio::hstdout().unwrap();
-            write!(hstdout, "x = {}\n", x);
+        // write something through semihosting interface
+        let mut hstdout = semihosting::hio::hstdout().unwrap();
+        write!(hstdout, "x = {}\n", x);
 
-            // system call to exit successfully
-            semihosting::syscall1(
-                semihosting::nr::REPORT_EXCEPTION,
-                semihosting::debug::Exception::ApplicationExit as usize,
-            );
+        // exit from qemu
+        semihosting::debug::exit(semihosting::debug::EXIT_SUCCESS);
+
+        // hint to the optimizer that any code path which calls this function is statically unreachable
+        unsafe {
+            unreachable::unreachable();
         }
     }
 }


### PR DESCRIPTION
This will add a feature `semihosting` that 
- prints 'x = 42' and 
- cleanly exits from qemu.

My plan is to use this feature in rust compiler's CI.